### PR TITLE
Fix to openFile - open document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 # OS X
 .DS_Store
 
-# Intellij
-*.iml
-.idea
-
 # npm / yarn
 node_modules
 package-lock.json
@@ -17,3 +13,7 @@ styles.css
 manifest.json
 data.json
 hot-reload.bat
+
+# VS Code
+.vscode
+

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,7 @@ https://github.com/zsviczian/obsidian-stakeholder-actions
 export default {
   input: './src/main.ts',
   output: {
-    dir: '.',
+    dir: 'dist',
     sourcemap: 'inline',
     //    sourcemapExcludeSources: isProd,
     format: 'cjs',

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,10 @@ export default class ActionTrackerPlugin extends Plugin {
         todos: todos,
         openFile: (filePath: string) => {
           const file = this.app.vault.getAbstractFileByPath(filePath) as TFile;
-          this.app.workspace.splitActiveLeaf().openFile(file);
+          if(this.app.workspace.getActiveFile()==null) 
+            this.app.workspace.activeLeaf.openFile(file);
+          else
+            this.app.workspace.splitActiveLeaf().openFile(file);
         },
         toggleTodo: (todo: TodoItem, newStatus: TodoItemStatus) => {
           this.todoIndex.setStatus(todo, newStatus);


### PR DESCRIPTION
If there is no open file, then openFile opens in the main document area, if there is a document open, it opens it in the side pane.

I also optimized  .gitignore for vscode

also modified rollup to output to a dist folder (makes it easier for testing by using hard links from Obsidian plugin folder to the distribution folder)